### PR TITLE
Update terraform version to 1.4.1

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.3.4"
+  required_version = "~> 1.4.1"
 
   required_providers {
     aws = {


### PR DESCRIPTION
We run terraform 1.4.4. This will allow us to use this module without needing to deal with multiple versions. thanks!